### PR TITLE
Collect values in intermediate representation

### DIFF
--- a/plugins/qcheck-stm/src/config.ml
+++ b/plugins/qcheck-stm/src/config.ml
@@ -50,6 +50,6 @@ let init path init sut =
   match get_sut_ts_from_signature sut sigs with
   | Some sut -> (
       match get_init_id_from_signature sut init sigs with
-      | Some init -> Ok { context; init; sut }
+      | Some init -> Ok ({ context; init; sut }, sigs)
       | None -> Error "Can't find init function")
   | None -> Error "Can't find sut"

--- a/plugins/qcheck-stm/src/ir.ml
+++ b/plugins/qcheck-stm/src/ir.ml
@@ -1,2 +1,2 @@
-type value = { id : string }
+type value = { id : string; ty : Ppxlib.core_type }
 type signature = value list

--- a/plugins/qcheck-stm/src/ir.ml
+++ b/plugins/qcheck-stm/src/ir.ml
@@ -1,0 +1,2 @@
+type value = { id : string }
+type signature = value list

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -29,7 +29,11 @@ let is_stmable config vd =
       && List.for_all (lb_arg_is_not_of_type config.sut) vd.vd_ret
 
 let val_desc config vd =
-  if is_stmable config vd then Some { id = vd.vd_name.id_str } else None
+  if is_stmable config vd then
+    let id = vd.vd_name.id_str in
+    let ty = vd.vd_type in
+    Some { id; ty }
+  else None
 
 let sig_item config s =
   match s.sig_desc with

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -1,0 +1,15 @@
+open Gospel
+open Tast
+open Config
+open Ir
+
+let val_desc config vd =
+  let open Identifier.Ident in
+  if vd.vd_name = config.init then None else Some { id = vd.vd_name.id_str }
+
+let sig_item config s =
+  match s.sig_desc with
+  | Sig_val (vd, Nonghost) -> val_desc config vd
+  | _ -> None
+
+let signature config = List.filter_map (sig_item config)

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -4,6 +4,20 @@ open Config
 open Ir
 module Ident = Identifier.Ident
 
+type failure =
+  | Init_is_a_constant
+  | Init_has_multiple_sut_arguments
+  | Init_has_no_sut_argument
+  | Init_return_sut
+
+let flatten =
+  let rec aux acc = function
+    | [] -> acc
+    | Error err :: xs -> aux (err :: acc) xs
+    | _ :: xs -> aux acc xs
+  in
+  aux []
+
 let lb_arg_is_of_type ts = function
   | Lunit -> false
   | Lnone vs | Loptional vs | Lnamed vs | Lghost vs -> (
@@ -14,30 +28,37 @@ let lb_arg_is_of_type ts = function
 let lb_arg_is_not_of_type ty lb_arg = not (lb_arg_is_of_type ty lb_arg)
 
 let rec exactly_one p = function
-  | [] -> false
-  | x :: xs when p x -> List.exists p xs |> not
+  | [] -> Error Init_has_no_sut_argument
+  | x :: xs when p x ->
+      if List.exists p xs then Error Init_has_multiple_sut_arguments else Ok ()
   | _ :: xs -> exactly_one p xs
 
 let is_stmable config vd =
-  (* the value is not a constant *)
-  match vd.vd_args with
-  | [] -> false
-  | args ->
-      (* there is exactly one argument of the type sut *)
-      exactly_one (lb_arg_is_of_type config.sut) args
-      (* the function does not return a value of the type sut *)
-      && List.for_all (lb_arg_is_not_of_type config.sut) vd.vd_ret
+  let test_constant =
+    match vd.vd_args with [] -> Error Init_is_a_constant | _ -> Ok ()
+  in
+  let test_return =
+    if List.for_all (lb_arg_is_not_of_type config.sut) vd.vd_ret then Ok ()
+    else Error Init_return_sut
+  in
+  flatten
+    [
+      test_constant;
+      exactly_one (lb_arg_is_of_type config.sut) vd.vd_args;
+      test_return;
+    ]
 
 let val_desc config vd =
-  if is_stmable config vd then
-    let id = vd.vd_name.id_str in
-    let ty = vd.vd_type in
-    Some { id; ty }
-  else None
+  match is_stmable config vd with
+  | [] ->
+      let id = vd.vd_name.id_str in
+      let ty = vd.vd_type in
+      Ok { id; ty }
+  | failures -> Error failures
 
 let sig_item config s =
   match s.sig_desc with
-  | Sig_val (vd, Nonghost) -> val_desc config vd
+  | Sig_val (vd, Nonghost) -> Some (val_desc config vd)
   | _ -> None
 
 let signature config = List.filter_map (sig_item config)

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -2,10 +2,34 @@ open Gospel
 open Tast
 open Config
 open Ir
+module Ident = Identifier.Ident
+
+let lb_arg_is_of_type ts = function
+  | Lunit -> false
+  | Lnone vs | Loptional vs | Lnamed vs | Lghost vs -> (
+      match vs.vs_ty.ty_node with
+      | Tyapp (ts', _) -> Ttypes.ts_equal ts ts'
+      | _ -> false)
+
+let lb_arg_is_not_of_type ty lb_arg = not (lb_arg_is_of_type ty lb_arg)
+
+let rec exactly_one p = function
+  | [] -> false
+  | x :: xs when p x -> List.exists p xs |> not
+  | _ :: xs -> exactly_one p xs
+
+let is_stmable config vd =
+  (* the value is not a constant *)
+  match vd.vd_args with
+  | [] -> false
+  | args ->
+      (* there is exactly one argument of the type sut *)
+      exactly_one (lb_arg_is_of_type config.sut) args
+      (* the function does not return a value of the type sut *)
+      && List.for_all (lb_arg_is_not_of_type config.sut) vd.vd_ret
 
 let val_desc config vd =
-  let open Identifier.Ident in
-  if vd.vd_name = config.init then None else Some { id = vd.vd_name.id_str }
+  if is_stmable config vd then Some { id = vd.vd_name.id_str } else None
 
 let sig_item config s =
   match s.sig_desc with

--- a/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
@@ -1,6 +1,6 @@
 let main path init sut =
   match Config.init path init sut with
-  | Ok config ->
+  | Ok (config, _) ->
       let open Gospel.Identifier.Ident in
       let msg =
         "This will generate qcheck-stm tests using `"

--- a/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
@@ -1,3 +1,7 @@
+module Config = Config
+module Ir = Ir
+module Ir_of_gospel = Ir_of_gospel
+
 let main path init sut =
   match Config.init path init sut with
   | Ok (config, _) ->

--- a/plugins/qcheck-stm/test/dune
+++ b/plugins/qcheck-stm/test/dune
@@ -1,6 +1,16 @@
+(library
+ (name lib)
+ (modules lib)
+ (modules_without_implementation lib))
+
 (test
  (package ortac-qcheck-stm)
- (modules_without_implementation lib)
- (deps lib.mli)
  (name expect_stm)
- (libraries ortac_qcheck_stm))
+ (modules expect_stm)
+ (libraries ortac_qcheck_stm lib))
+
+(test
+ (package ortac-qcheck-stm)
+ (name expect_ir)
+ (modules expect_ir)
+ (libraries ortac_qcheck_stm lib))

--- a/plugins/qcheck-stm/test/expect_ir.expected
+++ b/plugins/qcheck-stm/test/expect_ir.expected
@@ -1,3 +1,1 @@
-Value bad_init will be tested
 Value f will be tested
-Value g will be tested

--- a/plugins/qcheck-stm/test/expect_ir.expected
+++ b/plugins/qcheck-stm/test/expect_ir.expected
@@ -1,0 +1,3 @@
+Value bad_init will be tested
+Value f will be tested
+Value g will be tested

--- a/plugins/qcheck-stm/test/expect_ir.expected
+++ b/plugins/qcheck-stm/test/expect_ir.expected
@@ -1,1 +1,1 @@
-Value f will be tested
+Value f of type sut -> int will be tested.

--- a/plugins/qcheck-stm/test/expect_ir.ml
+++ b/plugins/qcheck-stm/test/expect_ir.ml
@@ -1,10 +1,17 @@
 open Ortac_qcheck_stm
 
 let () =
+  let go v =
+    let open Ir in
+    let str =
+      "Value "
+      ^ v.id
+      ^ " of type "
+      ^ Ppxlib.string_of_core_type v.ty
+      ^ " will be tested."
+    in
+    print_endline str
+  in
   match Config.init "lib.mli" "good_init" "sut" with
   | Error err -> print_endline err
-  | Ok (config, sigs) ->
-      let ir = Ir_of_gospel.signature config sigs in
-      List.iter
-        (fun v -> print_endline ("Value " ^ v.Ir.id ^ " will be tested"))
-        ir
+  | Ok (config, sigs) -> Ir_of_gospel.signature config sigs |> List.iter go

--- a/plugins/qcheck-stm/test/expect_ir.ml
+++ b/plugins/qcheck-stm/test/expect_ir.ml
@@ -1,0 +1,10 @@
+open Ortac_qcheck_stm
+
+let () =
+  match Config.init "lib.mli" "good_init" "sut" with
+  | Error err -> print_endline err
+  | Ok (config, sigs) ->
+      let ir = Ir_of_gospel.signature config sigs in
+      List.iter
+        (fun v -> print_endline ("Value " ^ v.Ir.id ^ " will be tested"))
+        ir

--- a/plugins/qcheck-stm/test/expect_ir.ml
+++ b/plugins/qcheck-stm/test/expect_ir.ml
@@ -2,15 +2,18 @@ open Ortac_qcheck_stm
 
 let () =
   let go v =
-    let open Ir in
-    let str =
-      "Value "
-      ^ v.id
-      ^ " of type "
-      ^ Ppxlib.string_of_core_type v.ty
-      ^ " will be tested."
-    in
-    print_endline str
+    match v with
+    | Ok v ->
+        let open Ir in
+        let str =
+          "Value "
+          ^ v.id
+          ^ " of type "
+          ^ Ppxlib.string_of_core_type v.ty
+          ^ " will be tested."
+        in
+        print_endline str
+    | Error _ -> ()
   in
   match Config.init "lib.mli" "good_init" "sut" with
   | Error err -> print_endline err

--- a/plugins/qcheck-stm/test/lib.mli
+++ b/plugins/qcheck-stm/test/lib.mli
@@ -2,3 +2,5 @@ type sut
 
 val good_init : unit -> sut
 val bad_init : sut
+val f : sut -> int
+val g : int -> sut


### PR DESCRIPTION
This PR starts to build the `ortac-qcheck-plugin` intermediate representation.

Values that are not constant and that does not return a value of the type of the system under tests are collected.
Collected information is the identifier and the core_type.

