### PR TITLE
Collect values identifier in Ir.value

### DIFF
--- a/plugins/qcheck-stm/src/ir.ml
+++ b/plugins/qcheck-stm/src/ir.ml
@@ -25,9 +25,9 @@ type value = {
   precond : Tterm.term list;
 }
 
-let value =
+let value id =
   {
-    id = Ident.create ~loc:Location.none "dummy_id";
+    id;
     ty = Ppxlib.Ast_helper.Typ.any ();
     sut_var = Ident.create ~loc:Location.none "dummy_sut_var";
     args = [];
@@ -35,5 +35,9 @@ let value =
     postcond = { normal = []; exceptional = []; checks = [] };
     precond = [];
   }
+
+module Pp = struct
+  let value v = "id : " ^ v.id.Ident.id_str
+end
 
 type t = value list

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -3,6 +3,7 @@ open Tast
 open Reserr
 open Config
 
+(* XXX TODO should check the compatibility of the argument type too *)
 let lb_arg_is_of_type ts lb =
   match lb with
   | Lunit -> false

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -49,8 +49,7 @@ let sig_item config s =
   | Sig_val (vd, Nonghost) -> Some (val_desc config vd)
   | _ -> None
 
-let signature config =
-  List.filter_map (sig_item config)
+let signature config = List.filter_map (sig_item config)
 
 let run path init sut =
   (* temporary implementation until Config uses the new Reserr *)

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -1,0 +1,59 @@
+open Gospel
+open Tast
+open Reserr
+open Config
+
+let lb_arg_is_of_type ts lb =
+  match lb with
+  | Lunit -> false
+  | Lnone vs | Loptional vs | Lnamed vs | Lghost vs -> (
+      match vs.vs_ty.ty_node with
+      | Tyapp (ts', _) -> Ttypes.ts_equal ts ts'
+      | _ -> false)
+
+let lb_arg_is_not_of_type ty lb_arg = not (lb_arg_is_of_type ty lb_arg)
+
+let constant_test vd =
+  match vd.vd_args with
+  | [] -> Value_is_a_constant (vd.vd_loc, vd.vd_name) |> error
+  | _ -> ok vd
+
+let argument_test ty vd =
+  let p = lb_arg_is_of_type ty in
+  let rec exactly_one = function
+    | [] -> Value_have_no_sut_argument (vd.vd_loc, vd.vd_name) |> error
+    | x :: xs when p x ->
+        if List.exists p xs then
+          Value_have_multiple_sut_arguments (vd.vd_loc, vd.vd_name) |> error
+        else ok vd
+    | _ :: xs -> exactly_one xs
+  in
+  exactly_one vd.vd_args
+
+let return_test ty vd =
+  if List.for_all (lb_arg_is_not_of_type ty) vd.vd_ret then ok vd
+  else Value_return_sut (vd.vd_loc, vd.vd_name) |> error
+
+let value_id config vd =
+  let* _ = constant_test vd
+  and* _ = argument_test config.sut vd
+  and* _ = return_test config.sut vd in
+  ok vd.vd_name
+
+let val_desc config vd =
+  let* id = value_id config vd in
+  Ir.value id |> ok
+
+let sig_item config s =
+  match s.sig_desc with
+  | Sig_val (vd, Nonghost) -> Some (val_desc config vd)
+  | _ -> None
+
+let signature config =
+  List.filter_map (sig_item config)
+
+let run path init sut =
+  (* temporary implementation until Config uses the new Reserr *)
+  match Config.init path init sut with
+  | Ok (sigs, config) -> signature config sigs
+  | Error _err -> assert false

--- a/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
@@ -1,3 +1,7 @@
+module Ir = Ir
+module Ir_of_gospel = Ir_of_gospel
+module Reserr = Reserr
+
 let main path init sut =
   match Config.init path init sut with
   | Ok (_sigs, config) ->

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -1,4 +1,19 @@
-type error = |
+module Ident = Gospel.Identifier.Ident
+
+type error =
+  | Value_is_a_constant of (Ppxlib.location * Ident.t)
+  | Value_return_sut of (Ppxlib.location * Ident.t)
+  | Value_have_no_sut_argument of (Ppxlib.location * Ident.t)
+  | Value_have_multiple_sut_arguments of (Ppxlib.location * Ident.t)
+
+let error_to_string = function
+  | Value_is_a_constant (_loc, id) -> "Value `" ^ id.id_str ^ "' is a constant."
+  | Value_return_sut (_loc, id) -> "Value `" ^ id.id_str ^ "' returns a sut."
+  | Value_have_no_sut_argument (_loc, id) ->
+      "Value `" ^ id.id_str ^ "' have no sut argument"
+  | Value_have_multiple_sut_arguments (_loc, id) ->
+      "Value `" ^ id.id_str ^ "' have multiple sut arguments."
+
 type 'a reserr = ('a, error list) result
 
 let ok = Result.ok
@@ -10,3 +25,7 @@ let ( and* ) a b =
   | Error e0, Error e1 -> Error (e0 @ e1)
   | Error e, _ | _, Error e -> Error e
   | Ok a, Ok b -> Ok (a, b)
+
+let to_string pp = function
+  | Ok a -> pp a
+  | Error e -> String.concat "\n" (List.map error_to_string e)

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -1,7 +1,15 @@
-type error
+module Ident = Gospel.Identifier.Ident
+
+type error =
+  | Value_is_a_constant of (Ppxlib.location * Ident.t)
+  | Value_return_sut of (Ppxlib.location * Ident.t)
+  | Value_have_no_sut_argument of (Ppxlib.location * Ident.t)
+  | Value_have_multiple_sut_arguments of (Ppxlib.location * Ident.t)
+
 type 'a reserr
 
 val ok : 'a -> 'a reserr
 val error : error -> 'a reserr
 val ( let* ) : 'a reserr -> ('a -> 'b reserr) -> 'b reserr
 val ( and* ) : 'a reserr -> 'b reserr -> ('a * 'b) reserr
+val to_string : ('a -> string) -> 'a reserr -> string

--- a/plugins/qcheck-stm/test/dune
+++ b/plugins/qcheck-stm/test/dune
@@ -1,6 +1,16 @@
+(library
+ (name lib)
+ (modules lib)
+ (modules_without_implementation lib))
+
 (test
  (package ortac-qcheck-stm)
- (modules_without_implementation lib)
- (deps lib.mli)
  (name expect_stm)
- (libraries ortac_qcheck_stm))
+ (modules expect_stm)
+ (libraries ortac_qcheck_stm lib))
+
+(test
+ (package ortac-qcheck-stm)
+ (name expect_ir)
+ (modules expect_ir)
+ (libraries ortac_qcheck_stm lib))

--- a/plugins/qcheck-stm/test/expect_ir.expected
+++ b/plugins/qcheck-stm/test/expect_ir.expected
@@ -1,0 +1,11 @@
+Value `good_init' have no sut argument
+Value `good_init' returns a sut.
+Value `bad_init' is a constant.
+Value `bad_init' have no sut argument
+Value `bad_init' returns a sut.
+Value `no_sut' have no sut argument
+Value `constant' is a constant.
+Value `constant' have no sut argument
+Value `multiple_sut' have multiple sut arguments.
+id : f
+id : g

--- a/plugins/qcheck-stm/test/expect_ir.ml
+++ b/plugins/qcheck-stm/test/expect_ir.ml
@@ -1,0 +1,4 @@
+open Ortac_qcheck_stm
+
+let pp r = Reserr.to_string Ir.Pp.value r |> print_endline
+let () = Ir_of_gospel.run "lib.mli" "good_init" "sut" |> List.iter pp

--- a/plugins/qcheck-stm/test/lib.mli
+++ b/plugins/qcheck-stm/test/lib.mli
@@ -2,3 +2,8 @@ type sut
 
 val good_init : unit -> sut
 val bad_init : sut
+val no_sut : int -> int
+val constant : int
+val multiple_sut : sut -> sut -> int
+val f : sut -> int
+val g : int -> sut -> bool


### PR DESCRIPTION
Building on the new intermediary representation and using the reserr monad of PR #5, we collect the identifiers of the values that satisfy three criteria:
1. they are not constant (there is nothing to be tested by `qcheck-stm` here)
2. they don't return a value of the same type as the system under test (`qcheck-stm` does not support it yet)
3. they don't have multiple argument of the same type of the system under test (`qcheck-stm` does not support it yet)

These criteria are meant to be completed when we fill the Ir.value record with more information.