### PR TITLE
Make the reserr monad use the extensible Ortac_core warning mechanism

### DIFF
--- a/plugins/qcheck-stm/src/ir.ml
+++ b/plugins/qcheck-stm/src/ir.ml
@@ -36,8 +36,4 @@ let value id =
     precond = [];
   }
 
-module Pp = struct
-  let value v = "id : " ^ v.id.Ident.id_str
-end
-
-type t = value list
+let pp_value ppf v = Fmt.(pf ppf "id = %a@." Ident.pp v.id)

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -16,16 +16,17 @@ let lb_arg_is_not_of_type ty lb_arg = not (lb_arg_is_of_type ty lb_arg)
 
 let constant_test vd =
   match vd.vd_args with
-  | [] -> Value_is_a_constant (vd.vd_loc, vd.vd_name) |> error
+  | [] -> (Value_is_a_constant vd.vd_name.id_str, vd.vd_loc) |> error
   | _ -> ok vd
 
 let argument_test ty vd =
   let p = lb_arg_is_of_type ty in
   let rec exactly_one = function
-    | [] -> Value_have_no_sut_argument (vd.vd_loc, vd.vd_name) |> error
+    | [] -> (Value_have_no_sut_argument vd.vd_name.id_str, vd.vd_loc) |> error
     | x :: xs when p x ->
         if List.exists p xs then
-          Value_have_multiple_sut_arguments (vd.vd_loc, vd.vd_name) |> error
+          (Value_have_multiple_sut_arguments vd.vd_name.id_str, vd.vd_loc)
+          |> error
         else ok vd
     | _ :: xs -> exactly_one xs
   in
@@ -33,7 +34,7 @@ let argument_test ty vd =
 
 let return_test ty vd =
   if List.for_all (lb_arg_is_not_of_type ty) vd.vd_ret then ok vd
-  else Value_return_sut (vd.vd_loc, vd.vd_name) |> error
+  else (Value_return_sut vd.vd_name.id_str, vd.vd_loc) |> error
 
 let value_id config vd =
   let* _ = constant_test vd

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -16,17 +16,16 @@ let lb_arg_is_not_of_type ty lb_arg = not (lb_arg_is_of_type ty lb_arg)
 
 let constant_test vd =
   match vd.vd_args with
-  | [] -> (Value_is_a_constant vd.vd_name.id_str, vd.vd_loc) |> error
+  | [] -> (Constant_value vd.vd_name.id_str, vd.vd_loc) |> error
   | _ -> ok vd
 
 let argument_test ty vd =
   let p = lb_arg_is_of_type ty in
   let rec exactly_one = function
-    | [] -> (Value_have_no_sut_argument vd.vd_name.id_str, vd.vd_loc) |> error
+    | [] -> (No_sut_argument vd.vd_name.id_str, vd.vd_loc) |> error
     | x :: xs when p x ->
         if List.exists p xs then
-          (Value_have_multiple_sut_arguments vd.vd_name.id_str, vd.vd_loc)
-          |> error
+          (Multiple_sut_arguments vd.vd_name.id_str, vd.vd_loc) |> error
         else ok vd
     | _ :: xs -> exactly_one xs
   in
@@ -34,7 +33,7 @@ let argument_test ty vd =
 
 let return_test ty vd =
   if List.for_all (lb_arg_is_not_of_type ty) vd.vd_ret then ok vd
-  else (Value_return_sut vd.vd_name.id_str, vd.vd_loc) |> error
+  else (Returning_sut vd.vd_name.id_str, vd.vd_loc) |> error
 
 let value_id config vd =
   let* _ = constant_test vd

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -1,17 +1,17 @@
 module W = Ortac_core.Warnings
 
 type W.kind +=
-  | Value_is_a_constant of string
-  | Value_return_sut of string
-  | Value_have_no_sut_argument of string
-  | Value_have_multiple_sut_arguments of string
+  | Constant_value of string
+  | Returning_sut of string
+  | No_sut_argument of string
+  | Multiple_sut_arguments of string
 
 let level kind =
-    match kind with
-    | Value_is_a_constant _ | Value_return_sut _ | Value_have_no_sut_argument _
-    | Value_have_multiple_sut_arguments _ ->
-        W.Warning
-    | _ -> W.level kind
+  match kind with
+  | Constant_value _ | Returning_sut _ | No_sut_argument _
+  | Multiple_sut_arguments _ ->
+      W.Warning
+  | _ -> W.level kind
 
 type 'a reserr = ('a, W.t list) result
 
@@ -28,14 +28,13 @@ let ( and* ) a b =
 open Fmt
 
 let pp_kind ppf kind =
-    match kind with
-    | Value_is_a_constant id -> pf ppf "%a is a constant." W.quoted id
-    | Value_return_sut id -> pf ppf "%a returns a sut." W.quoted id
-    | Value_have_no_sut_argument id ->
-        pf ppf "%a have no sut argument." W.quoted id
-    | Value_have_multiple_sut_arguments id ->
-        pf ppf "%a have multiple sut arguments." W.quoted id
-    | _ -> W.pp_kind ppf kind
+  match kind with
+  | Constant_value id -> pf ppf "%a is a constant." W.quoted id
+  | Returning_sut id -> pf ppf "%a returns a sut." W.quoted id
+  | No_sut_argument id -> pf ppf "%a have no sut argument." W.quoted id
+  | Multiple_sut_arguments id ->
+      pf ppf "%a have multiple sut arguments." W.quoted id
+  | _ -> W.pp_kind ppf kind
 
 let pp_errors = W.pp_param pp_kind level |> list
 let pp pp_ok = Fmt.result ~ok:pp_ok ~error:pp_errors

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -1,15 +1,15 @@
-module Ident = Gospel.Identifier.Ident
+module W = Ortac_core.Warnings
 
-type error =
-  | Value_is_a_constant of (Ppxlib.location * Ident.t)
-  | Value_return_sut of (Ppxlib.location * Ident.t)
-  | Value_have_no_sut_argument of (Ppxlib.location * Ident.t)
-  | Value_have_multiple_sut_arguments of (Ppxlib.location * Ident.t)
+type W.kind +=
+  | Value_is_a_constant of string
+  | Value_return_sut of string
+  | Value_have_no_sut_argument of string
+  | Value_have_multiple_sut_arguments of string
 
 type 'a reserr
 
 val ok : 'a -> 'a reserr
-val error : error -> 'a reserr
+val error : W.t -> 'a reserr
 val ( let* ) : 'a reserr -> ('a -> 'b reserr) -> 'b reserr
 val ( and* ) : 'a reserr -> 'b reserr -> ('a * 'b) reserr
-val to_string : ('a -> string) -> 'a reserr -> string
+val pp : 'a Fmt.t -> 'a reserr Fmt.t

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -1,10 +1,10 @@
 module W = Ortac_core.Warnings
 
 type W.kind +=
-  | Value_is_a_constant of string
-  | Value_return_sut of string
-  | Value_have_no_sut_argument of string
-  | Value_have_multiple_sut_arguments of string
+  | Constant_value of string
+  | Returning_sut of string
+  | No_sut_argument of string
+  | Multiple_sut_arguments of string
 
 type 'a reserr
 

--- a/plugins/qcheck-stm/test/expect_ir.expected
+++ b/plugins/qcheck-stm/test/expect_ir.expected
@@ -1,11 +1,26 @@
-Value `good_init' have no sut argument
-Value `good_init' returns a sut.
-Value `bad_init' is a constant.
-Value `bad_init' have no sut argument
-Value `bad_init' returns a sut.
-Value `no_sut' have no sut argument
-Value `constant' is a constant.
-Value `constant' have no sut argument
-Value `multiple_sut' have multiple sut arguments.
-id : f
-id : g
+File "lib.mli", line 3, characters 0-27:
+Warning: `good_init' have no sut argument.
+File "lib.mli", line 3, characters 0-27:
+Warning: `good_init' returns a sut.
+File "lib.mli", line 4, characters 0-18:
+Warning: `bad_init' is a constant.
+
+File "lib.mli", line 4, characters 0-18:
+Warning: `bad_init' have no sut argument.
+File "lib.mli", line 4, characters 0-18:
+Warning: `bad_init' returns a sut.
+
+File "lib.mli", line 5, characters 0-23:
+Warning: `no_sut' have no sut argument.
+File "lib.mli", line 6, characters 0-18:
+Warning: `constant' is a constant.
+
+File "lib.mli", line 6, characters 0-18:
+Warning: `constant' have no sut argument.
+
+File "lib.mli", line 7, characters 0-36:
+Warning: `multiple_sut' have multiple sut arguments.
+
+id = f
+
+id = g

--- a/plugins/qcheck-stm/test/expect_ir.ml
+++ b/plugins/qcheck-stm/test/expect_ir.ml
@@ -1,4 +1,5 @@
 open Ortac_qcheck_stm
 
-let pp r = Reserr.to_string Ir.Pp.value r |> print_endline
-let () = Ir_of_gospel.run "lib.mli" "good_init" "sut" |> List.iter pp
+let () =
+  let pp = Fmt.(list (Reserr.pp Ir.pp_value) stdout) in
+  Ir_of_gospel.run "lib.mli" "good_init" "sut" |> pp


### PR DESCRIPTION
Building on [trunk#78](https://github.com/ocaml-gospel/ortac/pull/78), this PR proposes to make the reserr monad use the newly extensible type `Ortac_core.Warnings.kind` in place of `Reserr.error`. This allows to take advantage of the warning mechanism already implemented in `Ortac_core.Warnings` such as printing the location information and using levels of warnings.

This is a one commit Pr that does four things at the same time (in order to avoid commits that does not compile):
1. Make `error` an extension of `kind`
2. implement `level` and the formatter to handle the extension
3. modifies `Ir` accordingly
4. update the tests so that they use the formatter and print location information