### PR TITLE
Generate `postcond` stm function

### DIFF
--- a/plugins/qcheck-stm/src/ir.ml
+++ b/plugins/qcheck-stm/src/ir.ml
@@ -1,7 +1,7 @@
 open Gospel
 module Ident = Identifier.Ident
 
-type xpost = Ttypes.xsymbol * (Tterm.pattern * Tterm.term) list
+type xpost = Ttypes.xsymbol * Tterm.pattern * Tterm.term
 
 type next_state_formulae = {
   model : Ident.t; (* the name of the model's field *)
@@ -31,22 +31,21 @@ type value = {
   inst : (string * Ppxlib.core_type) list;
   sut_var : Ident.t;
   args : Ident.t option list; (* arguments of unit types are nameless *)
+  ret : Ident.t option;
   next_state : next_state;
   postcond : postcond;
   precond : Tterm.term list;
 }
 
-let value id ty inst sut_var args next_state =
-  {
-    id;
-    ty;
-    inst;
-    sut_var;
-    args;
-    next_state;
-    postcond = { normal = []; exceptional = []; checks = [] };
-    precond = [];
-  }
+let get_return_type value =
+  let open Ppxlib in
+  let rec aux ty =
+    match ty.ptyp_desc with Ptyp_arrow (_, _, r) -> aux r | _ -> ty
+  in
+  aux value.ty
+
+let value id ty inst sut_var args ret next_state postcond =
+  { id; ty; inst; sut_var; args; ret; next_state; postcond; precond = [] }
 
 type t = { state : (Ident.t * Ppxlib.core_type) list; values : value list }
 

--- a/plugins/qcheck-stm/src/ir.ml
+++ b/plugins/qcheck-stm/src/ir.ml
@@ -10,7 +10,7 @@ type next_state_formulae = {
 
 type term = int * Tterm.term
 
-(* XXX TODO decide whether we need checks here (if checks is true, state does
+(* XXX TODO decide whether we need checks here (if checks is false, state does
    not change) *)
 type next_state = {
   (* description of the new values are stored with the index of the
@@ -30,7 +30,7 @@ type value = {
   ty : Ppxlib.core_type;
   inst : (string * Ppxlib.core_type) list;
   sut_var : Ident.t;
-  args : Ident.t option list;
+  args : Ident.t option list; (* arguments of unit types are nameless *)
   next_state : next_state;
   postcond : postcond;
   precond : Tterm.term list;

--- a/plugins/qcheck-stm/src/ir.ml
+++ b/plugins/qcheck-stm/src/ir.ml
@@ -3,14 +3,24 @@ module Ident = Identifier.Ident
 
 type xpost = Ttypes.xsymbol * (Tterm.pattern * Tterm.term) list
 
+type next_state_formulae = {
+  model : Ident.t; (* the name of the model's field *)
+  description : Tterm.term; (* the new value for the model's field *)
+}
+
+type term = int * Tterm.term
+
+(* XXX TODO decide whether we need checks here (if checks is true, state does
+   not change) *)
 type next_state = {
-  formulae : Tterm.term list;
-  modifies : Tterm.term list;
-  checks : Tterm.term list;
+  (* description of the new values are stored with the index of the
+     postcondition they come from *)
+  formulae : (int * next_state_formulae) list;
+  modifies : Ident.t list;
 }
 
 type postcond = {
-  normal : Tterm.term list;
+  normal : term list;
   exceptional : xpost list;
   checks : Tterm.term list;
 }
@@ -20,20 +30,20 @@ type value = {
   ty : Ppxlib.core_type;
   inst : (string * Ppxlib.core_type) list;
   sut_var : Ident.t;
-  args : Ident.t list;
+  args : Ident.t option list;
   next_state : next_state;
   postcond : postcond;
   precond : Tterm.term list;
 }
 
-let value id ty inst =
+let value id ty inst sut_var args next_state =
   {
     id;
     ty;
     inst;
-    sut_var = Ident.create ~loc:Ppxlib.Location.none "dummy_sut_var";
-    args = [];
-    next_state = { formulae = []; modifies = []; checks = [] };
+    sut_var;
+    args;
+    next_state;
     postcond = { normal = []; exceptional = []; checks = [] };
     precond = [];
   }

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -83,7 +83,6 @@ let ty_var_substitution config (vd : val_description) =
 
 let split_args config ty args =
   let open Ppxlib in
-  let open Gospel.Tterm in
   let rec aux sut acc ty args =
     match (ty.ptyp_desc, args) with
     | _, Lghost _ :: xs -> aux sut acc ty xs
@@ -100,7 +99,7 @@ let split_args config ty args =
   | None, _ -> failwith "shouldn't happen (sut type not found)"
   | Some sut, args -> (sut, args)
 
-let next_state config sut state vd spec =
+let next_state sut state spec =
   let open Tterm in
   let is_t vs =
     let open Symbols in
@@ -139,7 +138,7 @@ let val_desc config state vd =
     of_option ~default:(No_spec vd.vd_name.id_str, vd.vd_loc) vd.vd_spec
   in
   let sut, args = split_args config vd.vd_type spec.sp_args in
-  let* next_state = next_state config sut state vd spec in
+  let* next_state = next_state sut state spec in
   Ir.value vd.vd_name vd.vd_type inst sut args next_state |> ok
 
 let sig_item config state s =

--- a/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
@@ -4,7 +4,15 @@ module Ir_of_gospel = Ir_of_gospel
 module Reserr = Reserr
 module Stm_of_ir = Stm_of_ir
 
-let main _path _init _sut = ()
+let main path init sut =
+  let open Reserr in
+  let pp = Fmt.((pp Ppxlib_ast.Pprintast.structure) stdout) in
+  let _ =
+    let* sigs, config = Config.init path init sut in
+    let* ir = Ir_of_gospel.run sigs config in
+    Stm_of_ir.stm config ir |> pp |> ok
+  in
+  ()
 
 open Cmdliner
 

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -147,4 +147,3 @@ let of_option ~default = Option.fold ~none:(error default) ~some:ok
 let to_option = function Ok x, _ -> Some x | _ -> None
 let map f l = List.map f l |> promote
 let concat_map f l = fmap List.concat (map f l)
-let filter_map f = List.filter_map (fun x -> to_option (f x))

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -20,13 +20,14 @@ type W.kind +=
   | Impossible_term_substitution of (string * [ `New | `Old ])
   | Ignored_modifies of string
   | Ensures_not_found_for_next_state of string
+  | Return_type_not_supported of string
 
 let level kind =
   match kind with
   | Constant_value _ | Returning_sut _ | No_sut_argument _
   | Multiple_sut_arguments _ | Incompatible_type _ | No_spec _
   | Impossible_term_substitution _ | Ignored_modifies _
-  | Ensures_not_found_for_next_state _ ->
+  | Ensures_not_found_for_next_state _ | Return_type_not_supported _ ->
       W.Warning
   | No_sut_type _ | No_init_function _ | Syntax_error_in_type _
   | Sut_type_not_supported _ | Type_not_supported_for_sut_parameter _
@@ -118,6 +119,8 @@ let pp_kind ppf kind =
         "No translatable `ensures` clause found to generate `next_state` for \
          model %a."
         W.quoted m
+  | Return_type_not_supported ty ->
+      pf ppf "Return type not supported %a." W.quoted ty
   | _ -> W.pp_kind ppf kind
 
 let pp_errors = W.pp_param pp_kind level |> Fmt.list

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -35,7 +35,6 @@ val of_option : default:W.t -> 'a option -> 'a reserr
 val to_option : 'a reserr -> 'a option
 val map : ('a -> 'b reserr) -> 'a list -> 'b list reserr
 val concat_map : ('a -> 'b list reserr) -> 'a list -> 'b list reserr
-val filter_map : ('a -> 'b reserr) -> 'a list -> 'b list
 val fmap : ('a -> 'b) -> 'a reserr -> 'b reserr
 val ( <$> ) : ('a -> 'b) -> 'a reserr -> 'b reserr
 val pp : 'a Fmt.t -> 'a reserr Fmt.t

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -20,6 +20,7 @@ type W.kind +=
   | Impossible_term_substitution of (string * [ `New | `Old ])
   | Ignored_modifies of string
   | Ensures_not_found_for_next_state of string
+  | Return_type_not_supported of string
 
 type 'a reserr
 

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -16,6 +16,10 @@ type W.kind +=
   | Incompatible_type of string
   | Sut_type_not_specified of string
   | No_models of string
+  | No_spec of string
+  | Impossible_term_substitution of (string * [ `New | `Old ])
+  | Ignored_modifies of string
+  | Ensures_not_found_for_next_state of string
 
 type 'a reserr
 
@@ -24,9 +28,14 @@ val error : W.t -> 'a reserr
 val warns : W.t list -> unit reserr
 val warn : W.t -> unit reserr
 val ( let* ) : 'a reserr -> ('a -> 'b reserr) -> 'b reserr
+val ( >>= ) : 'a reserr -> ('a -> 'b reserr) -> 'b reserr
 val ( and* ) : 'a reserr -> 'b reserr -> ('a * 'b) reserr
 val promote : 'a reserr list -> 'a list reserr
+val of_option : default:W.t -> 'a option -> 'a reserr
+val to_option : 'a reserr -> 'a option
 val map : ('a -> 'b reserr) -> 'a list -> 'b list reserr
+val concat_map : ('a -> 'b list reserr) -> 'a list -> 'b list reserr
+val filter_map : ('a -> 'b reserr) -> 'a list -> 'b list
 val fmap : ('a -> 'b) -> 'a reserr -> 'b reserr
 val ( <$> ) : ('a -> 'b) -> 'a reserr -> 'b reserr
 val pp : 'a Fmt.t -> 'a reserr Fmt.t

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -151,6 +151,7 @@ let next_state_case config state_ident value =
             (pick id))
         value.next_state.modifies
     in
+    (* [idx], like [descriptions], is in the order of the modifies clauses *)
     let idx = List.map (fun (i, _, _) -> i) descriptions in
     match
       List.map (fun (_, m, e) -> (lident (str_of_ident m), e)) descriptions
@@ -234,7 +235,6 @@ let postcond_case config idx state_ident new_state_ident value =
     in
     let* pat_ty = mk_pat_ret_ty value.inst ret_ty in
     let pat_ret =
-      (* FIXME ? *)
       match value.ret with
       | None -> ppat_any
       | Some id -> pvar (str_of_ident id)

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -112,14 +112,13 @@ let next_state_case config state_ident value =
   let* idx, rhs =
     (* substitute state variable when under `old` operator and translate description into ocaml *)
     let descriptions =
-      filter_map
+      List.filter_map
         (fun (i, { model; description }) ->
-          let* description =
-            subst_term ~gos_t:value.sut_var ~old_t:(Some state_ident)
-              ~new_t:None description
-            >>= term
-          in
-          ok (i, model, description))
+          subst_term ~gos_t:value.sut_var ~old_t:(Some state_ident) ~new_t:None
+            description
+          >>= term
+          |> to_option
+          |> Option.map (fun description -> (i, model, description)))
         value.next_state.formulae
     in
     (* choose one and only one description per modified model *)

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -211,5 +211,5 @@ let stm config ir =
   let cmd = cmd_type config ir in
   let state = state_type ir in
   let open Reserr in
-  let* idx, next_state = next_state config ir in
+  let* _idx, next_state = next_state config ir in
   ok [ cmd; state; next_state ]

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -12,7 +12,7 @@ let show_attribute : attribute =
     attr_loc = Location.none;
   }
 
-let subst inst ty =
+let subst_core_type inst ty =
   let rec aux ty =
     {
       ty with
@@ -43,13 +43,137 @@ let subst inst ty =
   in
   aux ty
 
+let subst_term ~gos_t ~old_t ~new_t term =
+  let exception ImpossibleSubst of (Gospel.Tterm.term * [ `New | `Old ]) in
+  let rec aux cur_t term =
+    let open Gospel.Tterm in
+    let next = aux cur_t in
+    match term.t_node with
+    | Tconst _ -> term
+    | Tvar { vs_name; vs_ty } when vs_name = gos_t -> (
+        match cur_t with
+        | Some cur_t -> { term with t_node = Tvar { vs_name = cur_t; vs_ty } }
+        | None ->
+            raise (ImpossibleSubst (term, if cur_t = new_t then `New else `Old))
+        )
+    | Tvar _ -> term
+    | Tapp (ls, terms) -> { term with t_node = Tapp (ls, List.map next terms) }
+    | Tfield (t, ls) -> { term with t_node = Tfield (next t, ls) }
+    | Tif (cnd, thn, els) ->
+        { term with t_node = Tif (next cnd, next thn, next els) }
+    | Tlet (vs, t1, t2) -> { term with t_node = Tlet (vs, next t1, next t2) }
+    | Tcase (t, brchs) ->
+        {
+          term with
+          t_node =
+            Tcase
+              ( next t,
+                List.map
+                  (fun (p, ot, t) -> (p, Option.map next ot, next t))
+                  brchs );
+        }
+    | Tquant (q, vs, t) -> { term with t_node = Tquant (q, vs, next t) }
+    | Tbinop (o, l, r) -> { term with t_node = Tbinop (o, next l, next r) }
+    | Tnot t -> { term with t_node = Tnot (next t) }
+    | Told t -> aux old_t t
+    | Ttrue -> term
+    | Tfalse -> term
+  in
+  let open Reserr in
+  try ok (aux new_t term)
+  with ImpossibleSubst (t, b) ->
+    error
+      ( Impossible_term_substitution
+          (Fmt.str "%a" Gospel.Tterm_printer.print_term t, b),
+        t.t_loc )
+
+let next_state_case config state_ident value =
+  let str_of_ident = Fmt.str "%a" Gospel.Identifier.Ident.pp in
+  let state_var = str_of_ident state_ident |> evar in
+  let lhs =
+    let pat_args = function
+      | None -> punit
+      | Some x -> ppat_var (noloc (str_of_ident x))
+    in
+    let args =
+      match value.args with
+      | [] -> None
+      | [ x ] -> Some (pat_args x)
+      | xs -> List.map pat_args xs |> ppat_tuple |> Option.some
+    in
+    let name = String.capitalize_ascii (str_of_ident value.id) |> lident in
+    ppat_construct name args
+  in
+  let open Reserr in
+  let term t =
+    let open Ortac_core.Ocaml_of_gospel in
+    try term ~context:config.Cfg.context t |> ok with W.Error e -> error e
+  in
+  let* idx, rhs =
+    (* substitute state variable when under `old` operator and translate description into ocaml *)
+    let descriptions =
+      filter_map
+        (fun (i, { model; description }) ->
+          let* description =
+            subst_term ~gos_t:value.sut_var ~old_t:(Some state_ident)
+              ~new_t:None description
+            >>= term
+          in
+          ok (i, model, description))
+        value.next_state.formulae
+    in
+    (* choose one and only one description per modified model *)
+    let pick id =
+      List.find_opt
+        (fun (_, m, _) -> Gospel.Identifier.Ident.equal id m)
+        descriptions
+    in
+    let* descriptions =
+      map
+        (fun id ->
+          of_option
+            ~default:
+              (Ensures_not_found_for_next_state (str_of_ident id), id.id_loc)
+            (pick id))
+        value.next_state.modifies
+    in
+    let idx = List.map (fun (i, _, _) -> i) descriptions in
+    match
+      List.map (fun (_, m, e) -> (lident (str_of_ident m), e)) descriptions
+    with
+    | [] -> ok (idx, state_var)
+    | fields ->
+        (idx, pexp_record fields (Some (evar (str_of_ident state_ident)))) |> ok
+  in
+  (idx, case ~lhs ~guard:None ~rhs) |> ok
+
+let next_state config ir =
+  let cmd_name = gen_symbol ~prefix:"cmd" () in
+  let state_name = gen_symbol ~prefix:"state" () in
+  let state_ident = Gospel.Tast.Ident.create ~loc:Location.none state_name in
+  let open Reserr in
+  let* idx_cases =
+    map
+      (fun v ->
+        let* i, c = next_state_case config state_ident v in
+        ok ((v.id, i), c))
+      ir.values
+  in
+  let idx, cases = List.split idx_cases in
+  let body = pexp_match (evar cmd_name) cases in
+  let pat = pvar "next_state" in
+  let expr =
+    efun [ (Nolabel, pvar cmd_name); (Nolabel, pvar state_name) ] body
+  in
+  (idx, pstr_value Nonrecursive [ value_binding ~pat ~expr ]) |> ok
+
 let cmd_constructor config value =
   let rec aux ty : Ppxlib.core_type list =
     match ty.ptyp_desc with
     | Ptyp_arrow (_, l, r) ->
         if Cfg.is_sut config l then aux r
         else
-          let x = subst value.inst l and xs = aux r in
+          let x = subst_core_type value.inst l and xs = aux r in
           x :: xs
     | _ -> []
   in
@@ -82,3 +206,10 @@ let cmd_type config ir =
       ~kind:(Ptype_variant constructors) ~private_:Public ~manifest:None
   in
   pstr_type Nonrecursive [ { td with ptype_attributes = [ show_attribute ] } ]
+
+let stm config ir =
+  let cmd = cmd_type config ir in
+  let state = state_type ir in
+  let open Reserr in
+  let* idx, next_state = next_state config ir in
+  ok [ cmd; state; next_state ]

--- a/plugins/qcheck-stm/test/dune
+++ b/plugins/qcheck-stm/test/dune
@@ -3,6 +3,11 @@
  (modules lib)
  (modules_without_implementation lib))
 
+(library
+ (name lib2)
+ (modules lib2)
+ (modules_without_implementation lib2))
+
 (test
  (package ortac-qcheck-stm)
  (name expect_config)
@@ -18,5 +23,6 @@
 (test
  (package ortac-qcheck-stm)
  (name expect_stm)
+ (deps lib2.mli)
  (modules expect_stm)
- (libraries ortac_qcheck_stm fmt gospel ppxlib ppxlib.astlib lib))
+ (libraries ortac_qcheck_stm fmt gospel ppxlib ppxlib.astlib lib2))

--- a/plugins/qcheck-stm/test/expect_ir.expected
+++ b/plugins/qcheck-stm/test/expect_ir.expected
@@ -1,16 +1,31 @@
 state = fst: char; snd: int
-values = id = f; ty = 'a -> ('a, 'b) t -> bool; inst = [b/int, a/char]
-
-id = g; ty = 'a -> ('b, 'a) t -> int; inst = [a/int, b/char]
-
+values = 
 File "lib.mli", line 5, characters 23-33:
 Warning: `make' returns a sut.
+
+File "lib.mli", line 5, characters 0-33:
+Warning: The function `make' is not specified.
+
+File "lib.mli", line 6, characters 0-32:
+Warning: The function `f' is not specified.
+
+File "lib.mli", line 7, characters 0-31:
+Warning: The function `g' is not specified.
 
 File "lib.mli", line 8, characters 8-40:
 Warning: `h' have multiple sut arguments.
 
+File "lib.mli", line 8, characters 0-40:
+Warning: The function `h' is not specified.
+
 File "lib.mli", line 9, characters 8-20:
 Warning: Type of system under test in `i' is incompatible with command line argument.
 
+File "lib.mli", line 9, characters 0-28:
+Warning: The function `i' is not specified.
+
 File "lib.mli", line 10, characters 8-21:
 Warning: Type of system under test in `j' is incompatible with command line argument.
+
+File "lib.mli", line 10, characters 0-35:
+Warning: The function `j' is not specified.

--- a/plugins/qcheck-stm/test/expect_stm.expected
+++ b/plugins/qcheck-stm/test/expect_stm.expected
@@ -32,3 +32,16 @@ let next_state cmd__001_ state__002_ =
              (Ortac_runtime.Gospelstdlib.integer_of_int 2) state__002_.size);
         contents = []
       }
+let postcond cmd__003_ state__004_ res__005_ =
+  let new_state__006_ = lazy (next_state cmd__003_ state__004_) in
+  match (cmd__003_, res__005_) with
+  | (Length, Res ((Int, _), i)) ->
+      List.fold_left (&&) true
+        [(Ortac_runtime.Gospelstdlib.integer_of_int i) =
+           (Ortac_runtime.Gospelstdlib.List.length
+              (Lazy.force new_state__006_).contents)]
+  | (Pop, Res ((Char, _), a_2)) ->
+      List.fold_left (&&) true
+        [a_2 = (Ortac_runtime.Gospelstdlib.List.hd state__004_.contents)]
+  | (Push a_1, Res ((Unit, _), _)) -> List.fold_left (&&) true []
+  | (Extend, Res ((Unit, _), _)) -> List.fold_left (&&) true []

--- a/plugins/qcheck-stm/test/expect_stm.expected
+++ b/plugins/qcheck-stm/test/expect_stm.expected
@@ -1,6 +1,34 @@
 type nonrec cmd =
-  | F of char 
-  | G of int [@@deriving show { with_path = false }]
+  | Length 
+  | Pop 
+  | Push of char 
+  | Extend [@@deriving show { with_path = false }]
 type nonrec state = {
-  fst: char ;
-  snd: int }
+  size: int ;
+  contents: char list }
+let next_state cmd__001_ state__002_ =
+  match cmd__001_ with
+  | Length -> state__002_
+  | Pop ->
+      {
+        state__002_ with
+        contents = (Ortac_runtime.Gospelstdlib.List.tl state__002_.contents)
+      }
+  | Push a_1 ->
+      {
+        state__002_ with
+        contents =
+          (if
+             (Ortac_runtime.Gospelstdlib.List.length state__002_.contents) =
+               state__002_.size
+           then state__002_.contents
+           else a_1 :: state__002_.contents)
+      }
+  | Extend ->
+      {
+        state__002_ with
+        size =
+          (Ortac_runtime.Gospelstdlib.( * )
+             (Ortac_runtime.Gospelstdlib.integer_of_int 2) state__002_.size);
+        contents = []
+      }

--- a/plugins/qcheck-stm/test/expect_stm.ml
+++ b/plugins/qcheck-stm/test/expect_stm.ml
@@ -1,4 +1,3 @@
-open Fmt
 open Ortac_qcheck_stm
 
 let _ = main "lib2.mli" "make 16 'a'" "char t"

--- a/plugins/qcheck-stm/test/expect_stm.ml
+++ b/plugins/qcheck-stm/test/expect_stm.ml
@@ -1,11 +1,9 @@
 open Fmt
 open Ortac_qcheck_stm
 
-let _ =
-  let open Reserr in
-  let* sigs, config = Config.init "lib.mli" "make 'a' 42" "(char, int) t" in
-  let* ir = Ir_of_gospel.run sigs config in
-  let cmd = Stm_of_ir.cmd_type config ir in
-  let state = Stm_of_ir.state_type ir in
-  pf stdout "%a@." Ppxlib_ast.Pprintast.structure [ cmd; state ];
-  ok ()
+let _ = main "lib2.mli" "make 16 'a'" "char t"
+(* let open Reserr in *)
+(* let pp = Fmt.((pp Ppxlib_ast.Pprintast.structure) stdout) in *)
+(* let* sigs, config = Config.init "lib2.mli" "make 16 'a'" "char t" in *)
+(* let* ir = Ir_of_gospel.run sigs config in *)
+(* Stm_of_ir.stm config ir |> pp |> ok *)

--- a/plugins/qcheck-stm/test/lib2.mli
+++ b/plugins/qcheck-stm/test/lib2.mli
@@ -1,0 +1,34 @@
+type 'a t
+(*@ model size : integer
+    model contents : 'a List.t *)
+
+val empty : int -> 'a t
+(*@ t = empty i
+    checks i > 0
+    ensures t.size = i
+    ensures t.contents = [] *)
+
+val length : 'a t -> int
+(*@ i = length t
+    ensures i = List.length t.contents *)
+
+val pop : 'a t -> 'a
+(*@ a = pop t
+    ensures a = List.hd (old t.contents)
+    modifies t.contents
+    modifies t.contents
+    ensures t.contents = List.tl (old t.contents) *)
+
+val push : 'a -> 'a t -> unit
+(*@ push a t
+    modifies t.contents
+    ensures t.contents = if List.length (old t.contents) = (old t.size)
+                         then (old t.contents)
+                         else (a :: (old t.contents)) *)
+
+val extend : 'a t -> unit
+(*@ extend t
+    modifies t.size
+    modifies t.contents
+    ensures t.contents = []
+    ensures t.size = 2 * old t.size *)


### PR DESCRIPTION
This PR build on #11 (ignore 6 first commits), and provide the generation of the `postcond` function based on the gospel postconditions.

No support is provided for now for exceptional postconditions and `checks` clauses. The plan is to add these features once we have a full story without them.
Normal postconditions used for `postcond` generation are the one that are not used for `next_state` generation.
The stm `postcond` function takes the state before the call as argument, we reuse the term substitution function to substitute the state identifiers under an `old` operator with the function argument (we made is the same name, so not much to do) and the one not under an `old` operator with a lazy call to the already generated `next_state` function.