### PR TITLE
Generate `run` stm function from gospel information

### DIFF
--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -20,14 +20,14 @@ type W.kind +=
   | Impossible_term_substitution of (string * [ `New | `Old ])
   | Ignored_modifies of string
   | Ensures_not_found_for_next_state of string
-  | Return_type_not_supported of string
+  | Type_not_supported of string
 
 let level kind =
   match kind with
   | Constant_value _ | Returning_sut _ | No_sut_argument _
   | Multiple_sut_arguments _ | Incompatible_type _ | No_spec _
   | Impossible_term_substitution _ | Ignored_modifies _
-  | Ensures_not_found_for_next_state _ | Return_type_not_supported _ ->
+  | Ensures_not_found_for_next_state _ | Type_not_supported _ ->
       W.Warning
   | No_sut_type _ | No_init_function _ | Syntax_error_in_type _
   | Sut_type_not_supported _ | Type_not_supported_for_sut_parameter _
@@ -125,8 +125,7 @@ let pp_kind ppf kind =
         "No translatable `ensures` clause found to generate `next_state` for \
          model %a."
         W.quoted m
-  | Return_type_not_supported ty ->
-      pf ppf "Return type not supported %a." W.quoted ty
+  | Type_not_supported ty -> pf ppf "Type not supported %a." W.quoted ty
   | _ -> W.pp_kind ppf kind
 
 let pp_errors = W.pp_param pp_kind level |> Fmt.list

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -68,6 +68,12 @@ let fmap f r =
 
 let ( <$> ) = fmap
 
+let app f r =
+  let* f = f and* r = r in
+  ok (f r)
+
+let ( <*> ) = app
+
 let pp_kind ppf kind =
   let open Fmt in
   match kind with

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -38,4 +38,6 @@ val map : ('a -> 'b reserr) -> 'a list -> 'b list reserr
 val concat_map : ('a -> 'b list reserr) -> 'a list -> 'b list reserr
 val fmap : ('a -> 'b) -> 'a reserr -> 'b reserr
 val ( <$> ) : ('a -> 'b) -> 'a reserr -> 'b reserr
+val app : ('a -> 'b) reserr -> 'a reserr -> 'b reserr
+val ( <*> ) : ('a -> 'b) reserr -> 'a reserr -> 'b reserr
 val pp : 'a Fmt.t -> 'a reserr Fmt.t

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -20,7 +20,7 @@ type W.kind +=
   | Impossible_term_substitution of (string * [ `New | `Old ])
   | Ignored_modifies of string
   | Ensures_not_found_for_next_state of string
-  | Return_type_not_supported of string
+  | Type_not_supported of string
 
 type 'a reserr
 

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -120,34 +120,71 @@ let mk_cmd_pattern value =
   let name = String.capitalize_ascii (str_of_ident value.id) |> lident in
   ppat_construct name args
 
-let ty_show_of_core_type inst ty =
+let munge_longident cap ty lid =
+  let open Reserr in
+  match lid.txt with
+  | Lident i | Ldot (Lident i, "t") | Ldot (Ldot (_, i), "t") | Ldot (_, i) ->
+      let f =
+        if cap then String.capitalize_ascii else String.uncapitalize_ascii
+      in
+      ok (f i)
+  | Lapply (_, _) ->
+      error
+        (Type_not_supported (Fmt.str "%a" Pprintast.core_type ty), ty.ptyp_loc)
+
+let pat_char = ppat_construct (lident "Char") None
+let exp_char = evar "char"
+
+let pat_of_core_type inst typ =
   let rec aux ty =
-    let open Ppxlib in
+    let open Reserr in
     match ty.ptyp_desc with
     | Ptyp_var v -> (
-        match List.assoc_opt v inst with None -> evar "char" | Some t -> aux t)
-    | Ptyp_constr (id, []) -> pexp_ident id
-    | Ptyp_constr (id, tys) ->
-        let args =
-          List.map
-            (fun t ->
-              let e = aux t in
-              (Nolabel, e))
-            tys
+        match List.assoc_opt v inst with None -> ok pat_char | Some t -> aux t)
+    | Ptyp_constr (c, xs) ->
+        let constr_str = lident <$> munge_longident true ty c
+        and pat_arg =
+          match xs with
+          | [] -> ok None
+          | xs -> (fun xs -> Some (ppat_tuple xs)) <$> map aux xs
         in
-        pexp_apply (pexp_ident id) args
+        ppat_construct <$> constr_str <*> pat_arg
     | _ ->
-        failwith "shouldn't happen (unsupported types should be caught before)"
+        error
+          ( Type_not_supported (Fmt.str "%a" Pprintast.core_type typ),
+            typ.ptyp_loc )
   in
-  aux ty
+  aux typ
+
+let exp_of_core_type inst typ =
+  let rec aux ty =
+    let open Reserr in
+    match ty.ptyp_desc with
+    | Ptyp_var v -> (
+        match List.assoc_opt v inst with None -> ok exp_char | Some t -> aux t)
+    | Ptyp_constr (c, xs) -> (
+        let constr_str = evar <$> munge_longident false ty c in
+        match xs with
+        | [] -> constr_str
+        | xs ->
+            pexp_apply
+            <$> constr_str
+            <*> (List.map (fun e -> (Nolabel, e)) <$> map aux xs))
+    | _ ->
+        error
+          ( Type_not_supported (Fmt.str "%a" Pprintast.core_type typ),
+            typ.ptyp_loc )
+  in
+  aux typ
 
 let exp_of_ident id = pexp_ident (lident (str_of_ident id))
 
 let run_case config sut_name value =
   let lhs = mk_cmd_pattern value in
-  let rhs =
+  let open Reserr in
+  let* rhs =
     let res = lident "Res" in
-    let ty_show = ty_show_of_core_type value.inst (Ir.get_return_type value) in
+    let* ty_show = exp_of_core_type value.inst (Ir.get_return_type value) in
     (* XXX TODO protect iff there are exceptional postconditions or checks *)
     (* let call = function_call_exp (evar sut_name) value in *)
     let call =
@@ -167,18 +204,19 @@ let run_case config sut_name value =
       pexp_apply efun (aux value.ty value.args)
     in
     let args = Some (pexp_tuple [ ty_show; call ]) in
-    pexp_construct res args
+    pexp_construct res args |> ok
   in
-  case ~lhs ~guard:None ~rhs
+  case ~lhs ~guard:None ~rhs |> ok
 
 let run config ir =
   let cmd_name = gen_symbol ~prefix:"cmd" () in
   let sut_name = gen_symbol ~prefix:"sut" () in
-  let cases = List.map (run_case config sut_name) ir.values in
+  let open Reserr in
+  let* cases = map (run_case config sut_name) ir.values in
   let body = pexp_match (evar cmd_name) cases in
   let pat = pvar "run" in
   let expr = efun [ (Nolabel, pvar cmd_name); (Nolabel, pvar sut_name) ] body in
-  pstr_value Nonrecursive [ value_binding ~pat ~expr ]
+  pstr_value Nonrecursive [ value_binding ~pat ~expr ] |> ok
 
 let next_state_case config state_ident value =
   let state_var = str_of_ident state_ident |> evar in
@@ -242,37 +280,6 @@ let next_state config ir =
   in
   (idx, pstr_value Nonrecursive [ value_binding ~pat ~expr ]) |> ok
 
-let pat_char = ppat_construct (lident "Char") None
-
-let munge_longident ty lid =
-  let open Reserr in
-  match lid.txt with
-  | Lident i | Ldot (Lident i, "t") | Ldot (Ldot (_, i), "t") | Ldot (_, i) ->
-      ok (String.capitalize_ascii i)
-  | Lapply (_, _) ->
-      error
-        ( Return_type_not_supported (Fmt.str "%a" Pprintast.core_type ty),
-          ty.ptyp_loc )
-
-let mk_pat_ret_ty inst ret_ty =
-  let rec aux ty =
-    let open Reserr in
-    match ty.ptyp_desc with
-    | Ptyp_var v -> (
-        match List.assoc_opt v inst with None -> ok pat_char | Some t -> aux t)
-    | Ptyp_constr (c, xs) ->
-        let* constr_str = munge_longident ty c and* pat_xs = map aux xs in
-        let pat_arg =
-          match pat_xs with [] -> None | xs -> Some (ppat_tuple xs)
-        in
-        ppat_construct (lident constr_str) pat_arg |> ok
-    | _ ->
-        error
-          ( Return_type_not_supported (Fmt.str "%a" Pprintast.core_type ret_ty),
-            ret_ty.ptyp_loc )
-  in
-  aux ret_ty
-
 let may_raise_exception v =
   match (v.postcond.exceptional, v.postcond.checks) with
   | [], [] -> false
@@ -290,10 +297,10 @@ let postcond_case config idx state_ident new_state_ident value =
       | Ptyp_var _ | Ptyp_constr _ -> ok ret_ty
       | _ ->
           error
-            ( Return_type_not_supported (Fmt.str "%a" Pprintast.core_type ret_ty),
+            ( Type_not_supported (Fmt.str "%a" Pprintast.core_type ret_ty),
               ret_ty.ptyp_loc )
     in
-    let* pat_ty = mk_pat_ret_ty value.inst ret_ty in
+    let* pat_ty = pat_of_core_type value.inst ret_ty in
     let pat_ret =
       match value.ret with
       | None -> ppat_any
@@ -429,5 +436,5 @@ let stm config ir =
   let open Reserr in
   let* idx, next_state = next_state config ir in
   let* postcond = postcond config idx ir in
-  let run = run config ir in
+  let* run = run config ir in
   ok [ cmd; state; next_state; postcond; run ]

--- a/plugins/qcheck-stm/test/expect_stm.expected
+++ b/plugins/qcheck-stm/test/expect_stm.expected
@@ -2,7 +2,8 @@ type nonrec cmd =
   | Length 
   | Pop 
   | Push of char 
-  | Extend [@@deriving show { with_path = false }]
+  | Extend 
+  | To_list [@@deriving show { with_path = false }]
 type nonrec state = {
   size: int ;
   contents: char list }
@@ -32,6 +33,7 @@ let next_state cmd__001_ state__002_ =
              (Ortac_runtime.Gospelstdlib.integer_of_int 2) state__002_.size);
         contents = []
       }
+  | To_list -> state__002_
 let postcond cmd__003_ state__004_ res__005_ =
   let new_state__006_ = lazy (next_state cmd__003_ state__004_) in
   match (cmd__003_, res__005_) with
@@ -45,3 +47,12 @@ let postcond cmd__003_ state__004_ res__005_ =
         [a_2 = (Ortac_runtime.Gospelstdlib.List.hd state__004_.contents)]
   | (Push a_1, Res ((Unit, _), _)) -> List.fold_left (&&) true []
   | (Extend, Res ((Unit, _), _)) -> List.fold_left (&&) true []
+  | (To_list, Res ((List (Char), _), l)) ->
+      List.fold_left (&&) true [l = (Lazy.force new_state__006_).contents]
+let run cmd__007_ sut__008_ =
+  match cmd__007_ with
+  | Length -> Res (int, (length sut__008_))
+  | Pop -> Res (char, (pop sut__008_))
+  | Push a_1 -> Res (unit, (push a_1 sut__008_))
+  | Extend -> Res (unit, (extend sut__008_))
+  | To_list -> Res ((list char), (to_list sut__008_))

--- a/plugins/qcheck-stm/test/lib2.mli
+++ b/plugins/qcheck-stm/test/lib2.mli
@@ -32,3 +32,7 @@ val extend : 'a t -> unit
     modifies t.contents
     ensures t.contents = []
     ensures t.size = 2 * old t.size *)
+
+val to_list : 'a t -> 'a list
+(*@ l = to_list t
+    ensures l = t.contents *)


### PR DESCRIPTION
This PR is a one commit PR based on #12 (ignore all but the last commit).

As for `postcond`, exception raising is not supported yet.
The generation of `run` is not monadic, as all the potential errors should have been caught in an earlier stage.