### PR TITLE
Generate `arb_cmd` stm function.

### DIFF
--- a/plugins/qcheck-stm/src/ir.ml
+++ b/plugins/qcheck-stm/src/ir.ml
@@ -30,7 +30,8 @@ type value = {
   ty : Ppxlib.core_type;
   inst : (string * Ppxlib.core_type) list;
   sut_var : Ident.t;
-  args : Ident.t option list; (* arguments of unit types are nameless *)
+  args : (Ppxlib.core_type * Ident.t option) list;
+      (* arguments of unit types can be nameless *)
   ret : Ident.t option;
   next_state : next_state;
   postcond : postcond;

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -90,8 +90,8 @@ let split_args config ty args =
     | Ptyp_arrow (_, l, r), Loptional vs :: xs
     | Ptyp_arrow (_, l, r), Lnamed vs :: xs ->
         if Cfg.is_sut config l then aux (Some vs.vs_name) acc r xs
-        else aux sut (Some vs.vs_name :: acc) r xs
-    | Ptyp_arrow (_, _, r), Lunit :: xs -> aux sut (None :: acc) r xs
+        else aux sut ((l, Some vs.vs_name) :: acc) r xs
+    | Ptyp_arrow (_, l, r), Lunit :: xs -> aux sut ((l, None) :: acc) r xs
     | _, [] -> (sut, List.rev acc)
     | _, _ -> failwith "shouldn't happen (too few parameters)"
   in

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -108,8 +108,8 @@ let str_of_ident = Fmt.str "%a" Gospel.Identifier.Ident.pp
 
 let mk_cmd_pattern value =
   let pat_args = function
-    | None -> punit
-    | Some x -> ppat_var (noloc (str_of_ident x))
+    | _, None -> punit
+    | _, Some x -> ppat_var (noloc (str_of_ident x))
   in
   let args =
     match value.args with

--- a/plugins/qcheck-stm/test/expect_stm.expected
+++ b/plugins/qcheck-stm/test/expect_stm.expected
@@ -7,6 +7,15 @@ type nonrec cmd =
 type nonrec state = {
   size: int ;
   contents: char list }
+let arb_cmd _ =
+  let open QCheck in
+    make ~print:show_cmd
+      (let open Gen in
+         [pure Length;
+         pure Pop;
+         (pure (fun a_1 -> Push a_1)) <*> char;
+         pure Extend;
+         pure To_list])
 let next_state cmd__001_ state__002_ =
   match cmd__001_ with
   | Length -> state__002_


### PR DESCRIPTION
This is a one commit PR based on #13 (ignore all commits but the last)

Implementation is quite straightforward.

Note that for now, we don't use any gospel preconditions in order to generate smarter `QCheck` generators.
This is planed for a future PR.